### PR TITLE
Remove no-secure flag from public cloud deployments

### DIFF
--- a/docs/guides/arcloud/_deployment_verification_secure.md
+++ b/docs/guides/arcloud/_deployment_verification_secure.md
@@ -8,7 +8,7 @@ Cluster Installation (arcloud)
 Enterprise Web:
 --------------
 
-http://<DOMAIN>/
+https://<DOMAIN>/
 
 Username: aradmin
 Password: <base64-encoded string>
@@ -16,7 +16,7 @@ Password: <base64-encoded string>
 Keycloak:
 ---------
 
-http://<DOMAIN>/auth/
+https://<DOMAIN>/auth/
 
 Username: admin
 Password: <base64-encoded string>
@@ -25,7 +25,7 @@ MinIO:
 ------
 
 kubectl -n arcloud port-forward svc/minio 8082:81
-http://127.0.0.1:8082/
+https://127.0.0.1:8082/
 
 Username: <base64-encoded string>
 Password: <base64-encoded string>
@@ -47,6 +47,6 @@ istio-system   istio-ingressgateway   LoadBalancer   <IPv4>   <IPv4>   80:31456/
 
 ## Log in to the Enterprise Console Web View
 
-1. Open the **Enterprise Web** url (`http://<DOMAIN>/`) in a browser
+1. Open the **Enterprise Web** url (`https://<DOMAIN>/`) in a browser
 2. Enter the provided credentials for **Enterprise Web**
 3. Verify the successful login

--- a/docs/guides/arcloud/_install_arcloud.md
+++ b/docs/guides/arcloud/_install_arcloud.md
@@ -42,17 +42,3 @@ kubectl --namespace ${NAMESPACE} create secret docker-registry container-registr
 ```shell
 docker login ${REGISTRY_SERVER} --username "${REGISTRY_USERNAME}" --password "${REGISTRY_PASSWORD}"
 ```
-
-### Setup AR Cloud
-
-```shell showLineNumbers
-./setup.sh \
-  --set global.domain=${DOMAIN} \
-  --no-secure \
-  --no-observability \
-  --accept-sla
-```
-
-:::note Software License Agreement
-Passing the `--accept-sla` flag assumes the acceptance of the [Magic Leap 2 Software License Agreement](https://www.magicleap.com/software-license-agreement-ml2).
-:::

--- a/docs/guides/arcloud/_install_arcloud_setup.md
+++ b/docs/guides/arcloud/_install_arcloud_setup.md
@@ -1,0 +1,13 @@
+### Setup AR Cloud
+
+```shell showLineNumbers
+./setup.sh \
+  --set global.domain=${DOMAIN} \
+  --no-secure \
+  --no-observability \
+  --accept-sla
+```
+
+:::note Software License Agreement
+Passing the `--accept-sla` flag assumes the acceptance of the [Magic Leap 2 Software License Agreement](https://www.magicleap.com/software-license-agreement-ml2).
+:::

--- a/docs/guides/arcloud/_install_arcloud_setup_secure.md
+++ b/docs/guides/arcloud/_install_arcloud_setup_secure.md
@@ -1,0 +1,12 @@
+### Setup AR Cloud
+
+```shell showLineNumbers
+./setup.sh \
+  --set global.domain=${DOMAIN} \
+  --no-observability \
+  --accept-sla
+```
+
+:::note Software License Agreement
+Passing the `--accept-sla` flag assumes the acceptance of the [Magic Leap 2 Software License Agreement](https://www.magicleap.com/software-license-agreement-ml2).
+:::

--- a/docs/guides/arcloud/_register_device.md
+++ b/docs/guides/arcloud/_register_device.md
@@ -1,0 +1,19 @@
+## Register a ML2 device
+
+### Web
+
+Perform the following from the web-based console:
+
+1. Log in to the **Enterprise Web** view
+2. Select **Devices** from the top-right menu options
+3. Select **Devices** from the dropdown menu options
+4. Click the **Configure Device** button
+
+### ML2
+
+Perform the following from within your ML2 device:
+
+1. Open **Settings** / **Setup ARCloud**
+2. Scan the displayed QR code
+
+**Enterprise Web** should list the registered device.

--- a/docs/guides/arcloud/aws.md
+++ b/docs/guides/arcloud/aws.md
@@ -12,7 +12,9 @@ import DownloadArcloud from './_download_arcloud.md';
 import InstallIstio from './_install_istio.md';
 import InstallIstioAws from './_install_istio_aws.md';
 import InstallArcloud from './_install_arcloud.md';
-import DeploymentVerification from './_deployment_verification.md';
+import InstallArcloudSetupSecure from './_install_arcloud_setup_secure.md';
+import DeploymentVerificationSecure from './_deployment_verification_secure.md';
+import RegisterDevice from './_register_device.md';
 
 This deployment strategy will provide a production-ready system using Amazon Web Services.
 
@@ -187,6 +189,10 @@ Minimum Requirements
 
 <InstallArcloud />
 
+<InstallArcloudSetupSecure />
+
 ## Verify Installation
 
-<DeploymentVerification />
+<DeploymentVerificationSecure />
+
+<RegisterDevice />

--- a/docs/guides/arcloud/gcp.md
+++ b/docs/guides/arcloud/gcp.md
@@ -11,7 +11,9 @@ description: "Enterprise deployment to Google Cloud Platform (GCP)"
 import DownloadArcloud from './_download_arcloud.md';
 import InstallIstio from './_install_istio.md';
 import InstallArcloud from './_install_arcloud.md';
-import DeploymentVerification from './_deployment_verification.md';
+import InstallArcloudSetupSecure from './_install_arcloud_setup_secure.md';
+import DeploymentVerificationSecure from './_deployment_verification_secure.md';
+import RegisterDevice from './_register_device.md';
 
 This deployment strategy will provide a production-ready system using Google Cloud.
 
@@ -123,6 +125,10 @@ Minimum Requirements:
 
 <InstallArcloud />
 
+<InstallArcloudSetupSecure />
+
 ## Verify Installation
 
-<DeploymentVerification />
+<DeploymentVerificationSecure />
+
+<RegisterDevice />

--- a/docs/guides/arcloud/on_prem.md
+++ b/docs/guides/arcloud/on_prem.md
@@ -13,7 +13,9 @@ import TabItem from '@theme/TabItem';
 import DownloadArcloud from './_download_arcloud.md';
 import InstallIstio from './_install_istio.md';
 import InstallArcloud from './_install_arcloud.md';
+import InstallArcloudSetup from './_install_arcloud_setup.md';
 import DeploymentVerification from './_deployment_verification.md';
+import RegisterDevice from './_register_device.md';
 
 This type of deployment is appropriate for any edge computing, on-premisis, or any other deployment strategy that does not involve [Google Cloud](/docs/guides/arcloud/arcloud-deployment-gcp) or [AWS](/docs/guides/arcloud/arcloud-deployment-aws).
 
@@ -218,6 +220,10 @@ brew install helm
 
 <InstallArcloud />
 
+<InstallArcloudSetup />
+
 ## Verify Installation
 
 <DeploymentVerification />
+
+<RegisterDevice />


### PR DESCRIPTION
Update instructions for Google Cloud and AWS to deploy without --no-secure flag.